### PR TITLE
StopAllSounds crash bug fix, some UX improvements

### DIFF
--- a/MidiControl/Configuration.cs
+++ b/MidiControl/Configuration.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace MidiControl
 {
@@ -102,8 +103,14 @@ namespace MidiControl
 
         public void SaveCurrentProfile()
         {
-            string json = JsonConvert.SerializeObject(Config);
-            File.WriteAllText(ConfFile, json);
+			try {
+				string json = JsonConvert.SerializeObject(Config);
+				File.WriteAllText(ConfFile, json);
+
+				MessageBox.Show("Configuration '" + CurrentProfile + "' saved successfully!");
+			} catch(Exception ex) {
+				MessageBox.Show("Error occurred while saving: " + ex.ToString());
+			}
         }
     }
 

--- a/MidiControl/Configuration.cs
+++ b/MidiControl/Configuration.cs
@@ -112,6 +112,19 @@ namespace MidiControl
 				MessageBox.Show("Error occurred while saving: " + ex.ToString());
 			}
         }
+
+		public void SaveCurrentProfileAs(string newname) {
+			ConfFile = Path.Combine(ConfFolder, Path.GetFileName("keybinds-" + removeInvalidChars.Replace(newname, "_") + ".json"));
+			try {
+				string json = JsonConvert.SerializeObject(Config);
+				File.WriteAllText(ConfFile, json);
+
+				CurrentProfile = newname;
+				MessageBox.Show("Configuration '" + CurrentProfile + "' saved successfully!");
+			} catch(Exception ex) {
+				MessageBox.Show("Error occurred while saving: " + ex.ToString());
+			}
+		}
     }
 
     public enum Event

--- a/MidiControl/Configuration.cs
+++ b/MidiControl/Configuration.cs
@@ -113,7 +113,8 @@ namespace MidiControl
 			}
         }
 
-		public void SaveCurrentProfileAs(string newname) {
+		public void SaveCurrentProfileAs(string newname)
+		{
 			ConfFile = Path.Combine(ConfFolder, Path.GetFileName("keybinds-" + removeInvalidChars.Replace(newname, "_") + ".json"));
 			try {
 				string json = JsonConvert.SerializeObject(Config);

--- a/MidiControl/EntryGUI.cs
+++ b/MidiControl/EntryGUI.cs
@@ -180,7 +180,8 @@ namespace MidiControl
                 {
                     ChkBoxStopAllSoundPress.Checked = true;
                 }
-                if(keybind.MIDIControlCallBackON.SwitchToProfile != "")
+                if(keybind.MIDIControlCallBackON.SwitchToProfile != "" &&
+					keybind.MIDIControlCallBackON.SwitchToProfile != null)
                 {
                     ChkBoxSwitchToProfilePress.Checked = true;
                     CboBoxProfilePress.SelectedItem = keybind.MIDIControlCallBackON.SwitchToProfile;
@@ -192,7 +193,8 @@ namespace MidiControl
                 {
                     ChkBoxStopAllSoundRelease.Checked = true;
                 }
-                if (keybind.MIDIControlCallBackOFF.SwitchToProfile != "")
+                if (keybind.MIDIControlCallBackOFF.SwitchToProfile != "" &&
+					keybind.MIDIControlCallBackOFF.SwitchToProfile != null)
                 {
                     ChkBoxSwitchToProfileRelease.Checked = true;
                     CboBoxProfileRelease.SelectedItem = keybind.MIDIControlCallBackOFF.SwitchToProfile;

--- a/MidiControl/MIDIControlGUI.cs
+++ b/MidiControl/MIDIControlGUI.cs
@@ -264,16 +264,7 @@ namespace MidiControl
         {
             if (e.KeyCode == Keys.Enter)
             {
-				bool createNew = false;
-				bool copyToNew = false;
-
-                if(! this.ComboBoxProfile.Items.Contains(this.ComboBoxProfile.Text))
-                {
-					//this.ComboBoxProfile.Items.Add(this.ComboBoxProfile.Text);
-					createNew = true;
-                }
-
-				if(createNew)
+				if(!this.ComboBoxProfile.Items.Contains(this.ComboBoxProfile.Text))
 					{
 					switch(MessageBox.Show("This profile doesn't exist (yet).  Do you want to copy your current settings for profile '" + conf.CurrentProfile + "' into new profile '" + this.ComboBoxProfile.Text + "?", "New profile", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question))
 					{

--- a/MidiControl/MIDIControlGUI.cs
+++ b/MidiControl/MIDIControlGUI.cs
@@ -264,12 +264,40 @@ namespace MidiControl
         {
             if (e.KeyCode == Keys.Enter)
             {
+				bool createNew = false;
+				bool copyToNew = false;
+
                 if(! this.ComboBoxProfile.Items.Contains(this.ComboBoxProfile.Text))
                 {
-                    this.ComboBoxProfile.Items.Add(this.ComboBoxProfile.Text);
+					//this.ComboBoxProfile.Items.Add(this.ComboBoxProfile.Text);
+					createNew = true;
                 }
-                this.ComboBoxProfile.SelectedItem = this.ComboBoxProfile.Text;
-                conf.LoadProfile(this.ComboBoxProfile.SelectedItem.ToString());
+
+				if(createNew)
+					{
+					switch(MessageBox.Show("This profile doesn't exist (yet).  Do you want to copy your current settings for profile '" + conf.CurrentProfile + "' into new profile '" + this.ComboBoxProfile.Text + "?", "New profile", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question))
+					{
+						case DialogResult.Yes:
+							conf.CurrentProfile = this.ComboBoxProfile.Text;
+							this.ComboBoxProfile.Items.Add(this.ComboBoxProfile.Text);
+							conf.SaveCurrentProfileAs(this.ComboBoxProfile.Text);
+							this.ComboBoxProfile.SelectedItem = this.ComboBoxProfile.Text;
+							break;
+						case DialogResult.No:
+							// original behavior
+							this.ComboBoxProfile.Items.Add(this.ComboBoxProfile.Text);
+							this.ComboBoxProfile.SelectedItem = this.ComboBoxProfile.Text;
+							conf.LoadProfile(this.ComboBoxProfile.SelectedItem.ToString());
+							break;
+						case DialogResult.Cancel:
+							break;
+					}
+				}
+				else
+				{
+					this.ComboBoxProfile.SelectedItem = this.ComboBoxProfile.Text;
+					conf.LoadProfile(this.ComboBoxProfile.SelectedItem.ToString());
+				}
             }
         }
 
@@ -285,10 +313,13 @@ namespace MidiControl
                 return;
             }
 
-            string currProfile = this.ComboBoxProfile.SelectedItem.ToString();
-            this.ComboBoxProfile.Items.Clear();
-            this.ComboBoxProfile.Items.AddRange(conf.RemoveProfile(currProfile));
-            this.ComboBoxProfile.SelectedItem = "Default";
+			if(MessageBox.Show("You are about to delete the profile '" + conf.CurrentProfile + "'.  Are you sure you want to do this?", "Confirm profile delete", MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.Yes)
+			{
+				string currProfile = this.ComboBoxProfile.SelectedItem.ToString();
+				this.ComboBoxProfile.Items.Clear();
+				this.ComboBoxProfile.Items.AddRange(conf.RemoveProfile(currProfile));
+				this.ComboBoxProfile.SelectedItem = "Default";
+			}
         }
     }
 }

--- a/MidiControl/MIDIListener.cs
+++ b/MidiControl/MIDIListener.cs
@@ -255,7 +255,8 @@ namespace MidiControl
                         {
                             audioControl.StopAll();
                         }
-                        if(entry.Value.MIDIControlCallBackON.SwitchToProfile != "")
+                        if(entry.Value.MIDIControlCallBackON.SwitchToProfile != "" &&
+							entry.Value.MIDIControlCallBackON.SwitchToProfile != null)
                         {
                             conf.LoadProfile(entry.Value.MIDIControlCallBackON.SwitchToProfile);
                         }
@@ -303,7 +304,8 @@ namespace MidiControl
                         {
                             audioControl.StopAll();
                         }
-                        if (entry.Value.MIDIControlCallBackOFF.SwitchToProfile != "")
+                        if (entry.Value.MIDIControlCallBackOFF.SwitchToProfile != "" &&
+							entry.Value.MIDIControlCallBackOFF.SwitchToProfile != null)
                         {
                             conf.LoadProfile(entry.Value.MIDIControlCallBackOFF.SwitchToProfile);
                         }


### PR DESCRIPTION
- fixed issue where saving Stop All Sounds to a control and using it would cause a crash because SwitchToProfile was set to null (correctly) but the event handler was checking for empty string
- fixed Switch To Profile box in EntryGUI being checked when editing a control where its value is null because it was supposed to be off (same bug)
- added copying current profile to a new one
- added confirm dialog for deleting a profile